### PR TITLE
Create a suffix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ To change the default list of kept tags, add this line to your `config.php` and 
 'hashandsalt.chopper.keep' => '<p><a><strong><em><sub><sup><blockquote><figure><img><h1><h2><h3><h4><h5><h6>',
 ```
 
+To append every time an arrow at the end, add this line to your `config.php`:
+
+```
+'hashandsalt.chopper.suffix' => '→',
+```
+
 ## Requirements
 
 This plugin was built using Kirby 3.0. Will not work on earlier versions.

--- a/index.php
+++ b/index.php
@@ -20,18 +20,20 @@ require('lib/TruncateHTML.php');
 Kirby::plugin('hashandsalt/chopper', [
 	// Options
 	'options' => [
-		'keep' => '<p><a><strong><em><sub><sup><blockquote><figure><img><h1><h2><h3><h4><h5><h6>'
+		'keep' => '<p><a><strong><em><sub><sup><blockquote><figure><img><h1><h2><h3><h4><h5><h6>',
+		'suffix' => '…'
   ],
 
 	'fieldMethods' => [
-		'chopper' => function ($field, $length = 250, $type = 'words', $elipses = '…') {
+		'chopper' => function ($field, $length = 250, $type = 'words', $suffix = '') {
 
 		$chopper = $field->kt();
+		$suffix = !empty($suffix) ? $suffix : option('hashandsalt.chopper.suffix');
 
 		if($type == 'words') {
-			$field = TruncateHTML::truncateWords($chopper, $length, $elipses);
+			$field = TruncateHTML::truncateWords($chopper, $length, $suffix);
 		} else {
-			$field = TruncateHTML::truncateChars($chopper, $length, $elipses);
+			$field = TruncateHTML::truncateChars($chopper, $length, $suffix);
 		}
 
 		$chopped = strip_tags($field, option('hashandsalt.chopper.keep'));


### PR DESCRIPTION
Hi !
If I want to append a custom arrow all the time I use `chopper()`, I think an option to change the default one could be useful.

Thanks for this great plugin, I was starting creating mine, but here a PR.